### PR TITLE
Fixes for nodemailer and mailjet API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ package-lock.json
 # Env variables
 .env
 
+# Intellij Idea
+.idea

--- a/lib/mailjet-transport.js
+++ b/lib/mailjet-transport.js
@@ -19,9 +19,11 @@ const headersParser = utils.headersParser;
 function parseAddress(address, parseBulk) {
   const addrs = addressParser(address || '');
 
-  return parseBulk
-    ? (addrs || []).map(addressFormatter).join(',')
-    : addressFormatter(addrs[0] || {});
+  if (parseBulk) {
+    const addresses = (addrs || []).map(addressFormatter);
+    return addresses.length > 0 ? addresses : '';
+  }
+  return addressFormatter(addrs[0] || {});
 }
 function MailjetTransport(options) {
   this.name = 'Mailjet';
@@ -37,18 +39,24 @@ function MailjetTransport(options) {
  *  Send a single email via Mailjet API
  *
  * @param {Object} mail
+ * @param  {Function} callback
  */
-MailjetTransport.prototype.send = async function (mail) {
-  const message = await this._parse(mail);
-  const requestOptions = {
-    Messages: [message],
-    SandboxMode: this.SandboxMode || false
-  };
-  const request = this.client
-    .post(SEND_METHOD, { version: API_VERSION })
-    .request(requestOptions);
+MailjetTransport.prototype.send = async function (mail, callback) {
+  try {
+    const message = await this._parse(mail);
+    const requestOptions = {
+      Messages: [message],
+      SandboxMode: this.SandboxMode || false
+    };
 
-  return request;
+    const result = await this.client
+      .post(SEND_METHOD, { version: API_VERSION })
+      .request(requestOptions);
+
+    callback(null, { envelope: result.body });
+  } catch (error) {
+    callback(error);
+  }
 };
 
 /**
@@ -58,18 +66,22 @@ MailjetTransport.prototype.send = async function (mail) {
  * @param  {Array}  mails
  * @param  {Function}  callback
  */
-MailjetTransport.prototype.sendBatch = async function (mails) {
-  const messages = await this._parse(mails);
-  const requestOptions = {
-    Messages: messages,
-    SandboxMode: this.SandboxMode || false
-  };
+MailjetTransport.prototype.sendBatch = async function (mails, callback) {
+  try {
+    const messages = await this._parse(mails);
+    const requestOptions = {
+      Messages: messages,
+      SandboxMode: this.SandboxMode || false
+    };
 
-  const request = this.client
-    .post(SEND_METHOD, { version: API_VERSION })
-    .request(requestOptions);
+    const result = await this.client
+      .post(SEND_METHOD, { version: API_VERSION })
+      .request(requestOptions);
 
-  return request;
+    callback(null, { envelope: result.body });
+  } catch (error) {
+    callback(error);
+  }
 };
 
 /**

--- a/lib/message.js
+++ b/lib/message.js
@@ -20,33 +20,25 @@ function Message() {}
 Message.prototype.setFromAddress = function (fromAddress) {
   if (!fromAddress) { return; }
 
-  this.From = {
-    Email: fromAddress
-  };
+  this.From = fromAddress;
 };
 
 Message.prototype.setToAddress = function (toAddress) {
   if (!toAddress) { return; }
 
-  this.To = [{
-    Email: toAddress
-  }];
+  this.To = toAddress;
 };
 
 Message.prototype.setCcAddress = function (ccAddress) {
   if (!ccAddress) { return; }
 
-  this.Cc = [{
-    Email: ccAddress
-  }];
+  this.Cc = ccAddress;
 };
 
 Message.prototype.setBccAddress = function (bccAddress) {
   if (!bccAddress) { return; }
 
-  this.Bcc = [{
-    Email: bccAddress
-  }];
+  this.Bcc = bccAddress;
 };
 
 Message.prototype.setReplyToAddress = function (replyToAddress) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,14 +1,17 @@
 'use strict';
 
-const util = require('util');
 const addressparser = require('addressparser');
 
 function addressFormatter(addr) {
-  if (addr.address && addr.name) {
-    return util.format('"%s" <%s>', addr.name, addr.address);
-  }
+  if (!addr.address) return null;
 
-  return addr.address;
+  const address = {
+    Email: addr.address
+  };
+
+  if (addr.name) address.Name = addr.name;
+
+  return address;
 }
 
 function addressParser(addrs) {

--- a/test/mailjet-transport.test.js
+++ b/test/mailjet-transport.test.js
@@ -420,15 +420,24 @@ describe('MailjetTransport', () => {
   });
 
   describe('#send', () => {
-    it('should be able to send a single mail ()', async () => {
-      const result = await transport.send(mails[0]);
-      const info = JSON.parse(result.response.text);
-      expect(info).be.an('object');
-      const accepted = info.Messages[0].To;
+    it('should be able to send a single mail ()', (callback) => {
+      transport.send(mails[0], (error, sentLetter) => {
+        try {
+          if (error) return callback(error);
 
-      expect(accepted[0].Email).equal('jane@example.org');
-      expect(accepted[0].MessageID).be.a('number');
-      expect(accepted[0].MessageUUID).be.a('string');
+          const info = sentLetter.envelope;
+          expect(info).be.an('object');
+          const accepted = info.Messages[0].To;
+
+          expect(accepted[0].Email).equal('jane@example.org');
+          expect(accepted[0].MessageID).be.a('number');
+          expect(accepted[0].MessageUUID).be.a('string');
+
+          callback();
+        } catch (error) {
+          callback(error);
+        }
+      });
     });
 
     xit('should be able to send a single mail with template', async () => {
@@ -453,18 +462,27 @@ describe('MailjetTransport', () => {
   });
 
   describe('#sendBatch', () => {
-    it('should be able to send multiple mail (callback)', async () => {
-      const result = await transport.sendBatch(mails);
-      const info = JSON.parse(result.response.text);
-      expect(info).be.an('object');
+    it('should be able to send multiple mail (callback)', (callback) => {
+      transport.sendBatch(mails, (error, sentLetter) => {
+        try {
+          if (error) return callback(error);
 
-      expect(info.Messages[0].To[0].Email).equal('jane@example.org');
-      expect(info.Messages[0].To[0].MessageID).be.a('number');
-      expect(info.Messages[0].To[0].MessageUUID).be.a('string');
+          const info = sentLetter.envelope;
+          expect(info).be.an('object');
 
-      expect(info.Messages[1].To[0].Email).equal('john@example.org');
-      expect(info.Messages[1].To[0].MessageID).be.a('number');
-      expect(info.Messages[1].To[0].MessageUUID).be.a('string');
+          expect(info.Messages[0].To[0].Email).equal('jane@example.org');
+          expect(info.Messages[0].To[0].MessageID).be.a('number');
+          expect(info.Messages[0].To[0].MessageUUID).be.a('string');
+
+          expect(info.Messages[1].To[0].Email).equal('john@example.org');
+          expect(info.Messages[1].To[0].MessageID).be.a('number');
+          expect(info.Messages[1].To[0].MessageUUID).be.a('string');
+
+          callback();
+        } catch (error) {
+          callback(error);
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
There's several issues fixed in this pull request.

1) Nodemailer expects callback in send method. With current realization, sendMail promise (as in quick start example) never resolves. In tests send works because it is called directly. Real email send by transport that created by nodemailer and nodemailer can't recognize and handle promise from send method. 
Docs https://nodemailer.com/plugins/create/#transports

2) Mailjet do not accept several receivers in To, Cc, Bcc fields ("first@example.com, second@example.com") but nodemailer does. So to provide compatibility this fields need to be parsed and passed in mailjet lib as an array of objects with Email and Name fields instead of join(",") addresses.
Docs: https://github.com/mailjet/api-documentation/blob/master/guides/_send-api.md#message-json-properties